### PR TITLE
Support walking slices, recursive types & prepare for fetching secrets in batches

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -35,6 +35,12 @@ func (g *collector) collectSecretFields(v reflect.Value, path string) {
 			g.collectSecretFields(field, fmt.Sprintf("%v.%v", path, v.Type().Field(i).Name))
 		}
 
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			item := v.Index(i)
+			g.collectSecretFields(item, fmt.Sprintf("%v[%v]", path, i))
+		}
+
 	case reflect.String:
 		secretName, found := strings.CutPrefix(v.String(), "$SECRET:")
 		if !found {
@@ -51,7 +57,8 @@ func (g *collector) collectSecretFields(v reflect.Value, path string) {
 			fieldPath:  path,
 			secretName: secretName,
 		})
-	}
 
-	return
+	default:
+		return
+	}
 }

--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,57 @@
+package cloudsecrets
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type secretField struct {
+	value      reflect.Value
+	fieldPath  string
+	secretName string
+}
+
+type collector struct {
+	fields []*secretField
+	err    error
+}
+
+// Walks given reflect value recursively and collects any string fields with $SECRET: prefix.
+func (g *collector) collectSecretFields(v reflect.Value, path string) {
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			return
+		}
+
+		// Dereference pointer
+		g.collectSecretFields(v.Elem(), path)
+
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			g.collectSecretFields(field, fmt.Sprintf("%v.%v", path, v.Type().Field(i).Name))
+		}
+
+	case reflect.String:
+		secretName, found := strings.CutPrefix(v.String(), "$SECRET:")
+		if !found {
+			return
+		}
+
+		if !v.CanSet() {
+			g.err = errors.Join(g.err, fmt.Errorf("can't set field %v", path))
+			return
+		}
+
+		g.fields = append(g.fields, &secretField{
+			value:      v,
+			fieldPath:  path,
+			secretName: secretName,
+		})
+	}
+
+	return
+}

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,0 +1,87 @@
+package cloudsecrets
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type dbConfig struct {
+	User     string
+	Password string
+}
+
+type jwtSecret string
+
+type config1 struct {
+	DB         dbConfig
+	JWTSecrets []jwtSecret
+	unexported dbConfig
+}
+
+func TestCollectFields(t *testing.T) {
+	tt := []struct {
+		Input any
+		Out   []string // field paths
+		Error bool
+	}{
+		{
+			Input: &config1{
+				DB: dbConfig{
+					User:     "db-user",
+					Password: "db-password",
+				},
+			},
+			Out: []string{},
+		},
+		{
+			Input: &config1{
+				DB: dbConfig{
+					User:     "db-user",
+					Password: "$SECRET:secretName",
+				},
+				JWTSecrets: []jwtSecret{"$SECRET:jwtSecret1", "$SECRET:jwtSecret2", "nope"},
+			},
+			Out: []string{"secretName", "jwtSecret1", "jwtSecret2"},
+		},
+		{
+			Input: &config1{
+				unexported: dbConfig{ // unexported fields can't be updated via reflect pkg
+					User:     "db-user",
+					Password: "$SECRET:secretName", // match inside unexported field
+				},
+			},
+			Out:   []string{},
+			Error: true, // expect error
+		},
+	}
+
+	for i, tc := range tt {
+		i, tc := i, tc
+		t.Run(fmt.Sprintf("tt[%v]", i), func(t *testing.T) {
+			v := reflect.ValueOf(tc.Input)
+
+			c := &collector{}
+			c.collectSecretFields(v, fmt.Sprintf("tt[%v].input", i))
+
+			if tc.Error {
+				if c.err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if c.err != nil {
+					t.Errorf("unexpected error: %v", c.err)
+				}
+			}
+
+			if len(c.fields) != len(tc.Out) {
+				t.Errorf("expected %v secrets, got %v", len(tc.Out), len(c.fields))
+			}
+			for i := 0; i < len(c.fields); i++ {
+				if c.fields[i].secretName != tc.Out[i] {
+					t.Errorf("collected field[%v].secretName=%v doesn't match tc.Out[%v]=%v", i, c.fields[i].secretName, i, tc.Out[i])
+				}
+			}
+		})
+	}
+}

--- a/hydrate.go
+++ b/hydrate.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
-	"sync"
 
 	"github.com/0xsequence/go-cloudsecrets/gcp"
 	"github.com/0xsequence/go-cloudsecrets/nosecrets"
+	"github.com/davecgh/go-spew/spew"
+	"golang.org/x/sync/errgroup"
 )
 
 // Hydrate recursively walks a given config (struct pointer) and hydrates all
@@ -39,15 +39,14 @@ func Hydrate(ctx context.Context, providerName string, config interface{}) error
 	}
 
 	v := reflect.ValueOf(config)
-	return hydrateStruct(ctx, provider, v)
+	return hydrateConfig(ctx, provider, v)
 }
 
-func hydrateStruct(ctx context.Context, provider secretsProvider, v reflect.Value) error {
+func hydrateConfig(ctx context.Context, provider secretsProvider, v reflect.Value) error {
 	if v.Kind() == reflect.Ptr {
 		if v.IsNil() {
 			return fmt.Errorf("passed config is nil")
 		}
-
 		v = v.Elem()
 	}
 
@@ -55,61 +54,27 @@ func hydrateStruct(ctx context.Context, provider secretsProvider, v reflect.Valu
 		return fmt.Errorf("passed config must be struct, actual %s", v.Kind())
 	}
 
-	errCh := make(chan error)
-	wg := &sync.WaitGroup{}
-	hydrateStructFields(ctx, provider, v, wg, errCh)
-	go func() {
-		wg.Wait()
-		close(errCh)
-	}()
+	ga := &collector{}
+	ga.collectSecretFields(v, "")
 
-	select {
-	case err, ok := <-errCh:
-		if !ok {
+	fields := ga.fields
+
+	spew.Dump(fields)
+
+	g := &errgroup.Group{}
+	for _, field := range fields {
+		field := field
+
+		g.Go(func() error {
+			secretValue, err := provider.FetchSecret(ctx, field.secretName)
+			if err != nil {
+				return fmt.Errorf("failed to fetch secret %v=%q: %w", field.fieldPath, field.value.String(), err)
+			}
+			field.value.SetString(secretValue)
+
 			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("walking struct fields: %w", err)
-		}
+		})
 	}
 
-	return nil
-}
-
-func hydrateStructFields(ctx context.Context, provider secretsProvider, config reflect.Value, wg *sync.WaitGroup, errCh chan error) {
-	for i := 0; i < config.NumField(); i++ {
-		field := config.Field(i)
-
-		switch field.Kind() {
-		case reflect.Ptr:
-			if field.IsNil() {
-				continue
-			}
-			// Dereference pointer
-			field = field.Elem()
-
-		case reflect.Struct:
-			hydrateStructFields(ctx, provider, field, wg, errCh)
-			continue
-
-		case reflect.String:
-			if !field.CanSet() {
-				continue
-			}
-
-			secretName, found := strings.CutPrefix(field.String(), "$SECRET:")
-			if found {
-				wg.Add(1)
-				go func(fieldName string, field reflect.Value, secretName string) {
-					defer wg.Done()
-					secretValue, err := provider.FetchSecret(ctx, secretName)
-					if err != nil {
-						errCh <- fmt.Errorf("%v=%q: %w", fieldName, field.String(), err)
-						return
-					}
-					field.SetString(secretValue)
-				}(config.Type().Field(i).Name, field, secretName)
-			}
-		}
-	}
+	return g.Wait()
 }

--- a/hydrate.go
+++ b/hydrate.go
@@ -80,20 +80,23 @@ func hydrateStructFields(ctx context.Context, provider secretsProvider, config r
 	for i := 0; i < config.NumField(); i++ {
 		field := config.Field(i)
 
-		if field.Kind() == reflect.Ptr {
+		switch field.Kind() {
+		case reflect.Ptr:
 			if field.IsNil() {
 				continue
 			}
 			// Dereference pointer
 			field = field.Elem()
-		}
 
-		if field.Kind() == reflect.Struct {
+		case reflect.Struct:
 			hydrateStructFields(ctx, provider, field, wg, errCh)
 			continue
-		}
 
-		if field.Kind() == reflect.String && field.CanSet() {
+		case reflect.String:
+			if !field.CanSet() {
+				continue
+			}
+
 			secretName, found := strings.CutPrefix(field.String(), "$SECRET:")
 			if found {
 				wg.Add(1)

--- a/hydrate.go
+++ b/hydrate.go
@@ -53,13 +53,11 @@ func hydrateConfig(ctx context.Context, provider secretsProvider, v reflect.Valu
 		return fmt.Errorf("passed config must be struct, actual %s", v.Kind())
 	}
 
-	ga := &collector{}
-	ga.collectSecretFields(v, "config")
-
-	fields := ga.fields
+	c := &collector{}
+	c.collectSecretFields(v, "config")
 
 	g := &errgroup.Group{}
-	for _, field := range fields {
+	for _, field := range c.fields {
 		field := field
 
 		g.Go(func() error {

--- a/hydrate.go
+++ b/hydrate.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/0xsequence/go-cloudsecrets/gcp"
 	"github.com/0xsequence/go-cloudsecrets/nosecrets"
-	"github.com/davecgh/go-spew/spew"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -55,11 +54,9 @@ func hydrateConfig(ctx context.Context, provider secretsProvider, v reflect.Valu
 	}
 
 	ga := &collector{}
-	ga.collectSecretFields(v, "")
+	ga.collectSecretFields(v, "config")
 
 	fields := ga.fields
-
-	spew.Dump(fields)
 
 	g := &errgroup.Group{}
 	for _, field := range fields {

--- a/hydrate.go
+++ b/hydrate.go
@@ -55,6 +55,9 @@ func hydrateConfig(ctx context.Context, provider secretsProvider, v reflect.Valu
 
 	c := &collector{}
 	c.collectSecretFields(v, "config")
+	if c.err != nil {
+		return fmt.Errorf("failed to collect fields: %w", c.err)
+	}
 
 	g := &errgroup.Group{}
 	for _, field := range c.fields {

--- a/hydrate_test.go
+++ b/hydrate_test.go
@@ -31,13 +31,7 @@ type analytics struct {
 func TestFailWhenPassedValueIsNotStruct(t *testing.T) {
 	input := "hello"
 
-	v := reflect.ValueOf(input)
-	provider := mock.NewSecretsProvider(map[string]string{
-		"dbPassword":        "changethissecret",
-		"analyticsPassword": "AuthTokenSecret",
-	})
-
-	assert.Error(t, hydrateStruct(context.Background(), provider, v))
+	assert.Error(t, Hydrate(context.Background(), "", input))
 }
 
 func TestReplacePlaceholdersWithSecrets(t *testing.T) {
@@ -117,7 +111,7 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := reflect.ValueOf(tt.conf)
-			err := hydrateStruct(ctx, mock.NewSecretsProvider(tt.storage), v)
+			err := hydrateConfig(ctx, mock.NewSecretsProvider(tt.storage), v)
 			if err != nil {
 				if tt.wantErr {
 					assert.Equal(t, tt.wantConf, tt.conf)

--- a/hydrate_test.go
+++ b/hydrate_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 type config struct {
-	DB        db
-	Analytics analytics
-	Pass      string
+	DB         db
+	Analytics  analytics
+	Pass       string
+	JWTSecrets []string
 }
 
 type db struct {
@@ -55,6 +56,8 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 				"dbPassword":        "changethissecret",
 				"analyticsPassword": "AuthTokenSecret",
 				"pass":              "secret",
+				"jwtSecretV1":       "some-old-secret",
+				"jwtSecretV2":       "changeme-now",
 			},
 			conf: &config{
 				Pass: "$SECRET:pass",
@@ -68,6 +71,7 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 					Server:    "http://localhost:8000",
 					AuthToken: "$SECRET:analyticsPassword",
 				},
+				JWTSecrets: []string{"$SECRET:jwtSecretV2", "$SECRET:jwtSecretV1"},
 			},
 			wantErr: false,
 			wantConf: &config{
@@ -81,6 +85,10 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 					Enabled:   true,
 					Server:    "http://localhost:8000",
 					AuthToken: "AuthTokenSecret",
+				},
+				JWTSecrets: []string{
+					"changeme-now",
+					"some-old-secret",
 				},
 			},
 		},


### PR DESCRIPTION
- Walk any given config recursively (support nested structs, double-indirection etc.)
- Support slices and arrays
- Return slice of fields that were collected for secret hydration -- this will allow us to fetch secrets in batches, if supported by the provider

Possible limitation: If there is a circular dependency in the given config, we might hit an endless recursion. But is that even possible for configs? Perhaps we could add a limit on the depth of recursion.