### PR TITLE
Support map[string]config{} by creating a ptr to the config value

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -44,7 +44,19 @@ func (g *collector) collectSecretFields(v reflect.Value, path string) {
 	case reflect.Map:
 		for _, key := range v.MapKeys() {
 			item := v.MapIndex(key)
-			g.collectSecretFields(item, fmt.Sprintf("%v[%v]", path, key))
+
+			if item.Kind() == reflect.Struct {
+				// If the value is a struct, create a pointer to the map value and modify via pointer
+				ptr := reflect.New(item.Type())
+				ptr.Elem().Set(item)
+
+				g.collectSecretFields(ptr, fmt.Sprintf("%v[%v]", path, key))
+
+				// Set the modified struct back into the map
+				v.SetMapIndex(key, ptr.Elem())
+			} else {
+				g.collectSecretFields(item, fmt.Sprintf("%v[%v]", path, key))
+			}
 		}
 
 	case reflect.String:


### PR DESCRIPTION
A limitation of a `map[string]struct{}` is that we can't directly set struct's fields using reflect's `.SetValue()`. We need to create a pointer to the value first, update the field and then reassign the map with the new struct value.