### PR TITLE
Use hook to set map key after setter

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -125,7 +125,7 @@ func TestCollectFields(t *testing.T) {
 			v := reflect.ValueOf(tc.Input)
 
 			c := &collector{}
-			c.collectSecretFields(v, fmt.Sprintf("tt[%v].input", i), nil)
+			c.collectSecretFields(v, fmt.Sprintf("tt[%v].input", i))
 
 			if tc.Error {
 				if c.err == nil {

--- a/collector_test.go
+++ b/collector_test.go
@@ -125,7 +125,7 @@ func TestCollectFields(t *testing.T) {
 			v := reflect.ValueOf(tc.Input)
 
 			c := &collector{}
-			c.collectSecretFields(v, fmt.Sprintf("tt[%v].input", i))
+			c.collectSecretFields(v, fmt.Sprintf("tt[%v].input", i), nil)
 
 			if tc.Error {
 				if c.err == nil {

--- a/hydrate.go
+++ b/hydrate.go
@@ -54,7 +54,7 @@ func hydrateConfig(ctx context.Context, provider secretsProvider, v reflect.Valu
 	}
 
 	c := &collector{}
-	c.collectSecretFields(v, "config")
+	c.collectSecretFields(v, "config", nil)
 	if c.err != nil {
 		return fmt.Errorf("failed to collect fields: %w", c.err)
 	}
@@ -69,6 +69,9 @@ func hydrateConfig(ctx context.Context, provider secretsProvider, v reflect.Valu
 				return fmt.Errorf("failed to fetch secret %v=%q: %w", field.fieldPath, field.value.String(), err)
 			}
 			field.value.SetString(secretValue)
+			if field.hook != nil {
+				field.hook()
+			}
 
 			return nil
 		})

--- a/hydrate_test.go
+++ b/hydrate_test.go
@@ -20,6 +20,7 @@ type config struct {
 type service struct {
 	URL  string
 	Auth string
+	Pass string
 }
 
 type db struct {
@@ -75,7 +76,9 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 				JWTSecrets: []string{"$SECRET:jwtSecretV2", "$SECRET:jwtSecretV1"},
 				Services: map[string]service{
 					"a": {
+						URL:  "http://localhost:8000",
 						Auth: "$SECRET:auth",
+						Pass: "$SECRET:jwtSecretV2",
 					},
 				},
 			},
@@ -98,7 +101,9 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 				},
 				Services: map[string]service{
 					"a": {
+						URL:  "http://localhost:8000",
 						Auth: "auth-secret",
+						Pass: "changeme-now",
 					},
 				},
 			},

--- a/hydrate_test.go
+++ b/hydrate_test.go
@@ -14,6 +14,12 @@ type config struct {
 	Analytics  analytics
 	Pass       string
 	JWTSecrets []string
+	Services   map[string]service
+}
+
+type service struct {
+	URL  string
+	Auth string
 }
 
 type db struct {
@@ -52,6 +58,7 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 				"pass":              "secret",
 				"jwtSecretV1":       "some-old-secret",
 				"jwtSecretV2":       "changeme-now",
+				"auth":              "auth-secret",
 			},
 			conf: &config{
 				Pass: "$SECRET:pass",
@@ -66,6 +73,11 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 					AuthToken: "$SECRET:analyticsPassword",
 				},
 				JWTSecrets: []string{"$SECRET:jwtSecretV2", "$SECRET:jwtSecretV1"},
+				Services: map[string]service{
+					"a": {
+						Auth: "$SECRET:auth",
+					},
+				},
 			},
 			wantErr: false,
 			wantConf: &config{
@@ -83,6 +95,11 @@ func TestReplacePlaceholdersWithSecrets(t *testing.T) {
 				JWTSecrets: []string{
 					"changeme-now",
 					"some-old-secret",
+				},
+				Services: map[string]service{
+					"a": {
+						Auth: "auth-secret",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
A struct map value is not addressable, so even if we create a new addressable copy, we lose the addressable property the moment we set it in the map, since we dereference it.

The solution is to set the value in the map after the setters. 

This change collect the set operation in the collector as hooks, that get executed after the setters are done.